### PR TITLE
✨ Feat : 로그아웃, 로그인 기능 업데이트

### DIFF
--- a/src/main/java/com/energy/tajo/auth/controller/AuthController.java
+++ b/src/main/java/com/energy/tajo/auth/controller/AuthController.java
@@ -12,7 +12,7 @@ import com.energy.tajo.user.domain.User;
 import com.energy.tajo.user.dto.request.UserCreateRequest;
 import com.energy.tajo.user.repository.UserRepository;
 import com.energy.tajo.user.service.UserService;
-import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -75,8 +75,6 @@ public class AuthController {
         User user = User.of(checkedUuid, encryptedPassword, request.name(), request.email(), request.consentStatus());
         user.setPhoneNum(verifiedPhoneNumber);
         userRepository.save(user);
-
-        // JWT 생성
         String token = jwtTokenProvider.generateAccessToken(user.getUuid());
         return ResponseEntity.ok(token);
     }
@@ -92,10 +90,10 @@ public class AuthController {
     // 로그아웃
     @PostMapping("/logout")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void logout(HttpServletResponse response) {
-        TokenResponse.expireAccessToken(response);
+    public void logout(@RequestBody Map<String, String> requestBody) {
+        String uuid = requestBody.get("uuid");
+        authenticationService.invalidateRefreshToken(uuid);
     }
-
 
     // 토큰 갱신
     @PostMapping("/refresh")

--- a/src/main/java/com/energy/tajo/auth/service/AuthenticationService.java
+++ b/src/main/java/com/energy/tajo/auth/service/AuthenticationService.java
@@ -28,6 +28,10 @@ public class AuthenticationService {
 
         String accessToken = jwtTokenProvider.generateAccessToken(user.getUuid());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUuid());
+
+        user.setRefreshToken(refreshToken);
+        userRepository.save(user);
+
         return new TokenResponse(accessToken, refreshToken);
     }
 
@@ -36,5 +40,13 @@ public class AuthenticationService {
         String uuid = jwtTokenProvider.extractUuidFromRefreshToken(refreshToken);
         String newAccessToken = jwtTokenProvider.generateAccessToken(uuid);
         return new TokenResponse(newAccessToken, refreshToken);
+    }
+
+    public void invalidateRefreshToken(String uuid) {
+        User user = userRepository.findByUuid(uuid)
+            .orElseThrow(() -> new EnergyException(ErrorCode.USER_NOT_FOUND));
+
+        user.setRefreshToken(null);
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/energy/tajo/user/domain/User.java
+++ b/src/main/java/com/energy/tajo/user/domain/User.java
@@ -54,6 +54,9 @@ public class User extends BaseTimeEntity implements Serializable {
     @Column(nullable = false, name = "tot_power_gen")
     private int totPowerGen = 0;
 
+    @Column(name="refresh_token")
+    private String refreshToken;
+
     protected User() {
     }
 


### PR DESCRIPTION
- user 도메인 추가
- 로그인 시 : refresh Token을 User 테이블 refresh Token 컬럼에 추가
- 로그아웃 시 : refresh Token 무효화를 위해 User 테이블의 refresh Token 컬럼 null로 저장

## #️⃣ 연관된 이슈

> #16  #24

## 📝 작업 내용
> 기존 로그아웃 만료 처리 방식을 무효화 방식으로 수정
- [x] 로그아웃 시 refresh Token 무효화 (refresh Token 컬럼 null로 저장)
- [x] 로그인 시 refresh Token을 user 테이블 내 refresh Token 컬럼에 추가
- [x]  User 테이블 Refresh Token 관련 컬럼 추가
- [x] User 도메인 재설정